### PR TITLE
fix: adicionar opção force à sincronização com Glitch

### DIFF
--- a/.github/workflows/gcseic.yml
+++ b/.github/workflows/gcseic.yml
@@ -127,3 +127,4 @@ jobs:
         with:
           auth-token: "${{ secrets.authToken }}"
           project-id: "${{ secrets.projectId }}"
+          force: true


### PR DESCRIPTION
- Adicionada a opção force: true para sobrescrever arquivos conflitantes no Glitch
- Mantida a limpeza prévia de diretórios problemáticos como coverage e node_modules/.cache
- Solução para o erro "inter-device move failed: unable to remove target: Directory not empty"